### PR TITLE
fixed too much error logs when the target material doesn't have _MainTex property

### DIFF
--- a/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
+++ b/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
@@ -183,7 +183,9 @@ namespace cakeslice
                         {
                             Material m = null;
 
-                            if (outline.Renderer.sharedMaterials[v].mainTexture != null && outline.Renderer.sharedMaterials[v])
+                            if (outline.Renderer.sharedMaterials[v].HasProperty("_MainTex")
+                                && outline.Renderer.sharedMaterials[v].mainTexture != null
+                                && outline.Renderer.sharedMaterials[v])
                             {
                                 foreach (Material g in materialBuffer)
                                 {


### PR DESCRIPTION
多数のメッシュがある場合にログが多すぎて動作が重くなってしまうケースがあるため、チェックして出さないようにする。
